### PR TITLE
minor refactoring

### DIFF
--- a/src/main/java/com/boxfuse/cloudwatchlogs/internal/CloudwatchAppender.java
+++ b/src/main/java/com/boxfuse/cloudwatchlogs/internal/CloudwatchAppender.java
@@ -1,0 +1,49 @@
+package com.boxfuse.cloudwatchlogs.internal;
+
+import com.boxfuse.cloudwatchlogs.CloudwatchLogsConfig;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+/**
+ * Created by kawnayeen on 3/2/17.
+ */
+public class CloudwatchAppender {
+    private final CloudwatchLogsConfig config = new CloudwatchLogsConfig();
+    private BlockingQueue<CloudwatchLogsLogEvent> eventQueue;
+    private CloudwatchLogsLogEventPutter putter;
+    private long discardedCount;
+
+    public void start() {
+        eventQueue = new LinkedBlockingQueue<>(config.getMaxEventQueueSize());
+        putter = new CloudwatchLogsLogEventPutter(config, eventQueue);
+        new Thread(putter).start();
+    }
+
+    public void stop() {
+        putter.terminate();
+    }
+
+    public void append(CloudwatchLogsLogEvent logEvent) {
+        while (!eventQueue.offer(logEvent)) {
+            eventQueue.poll();
+            discardedCount++;
+        }
+    }
+
+    /**
+     * @return The config of the appender. This instance can be modified to override defaults.
+     */
+    public CloudwatchLogsConfig getConfig() {
+        return config;
+    }
+
+    /**
+     * @return The number of log events that had to be discarded because the event queue was full.
+     * If this number is non zero without having been affected by AWS CloudWatch Logs availability issues,
+     * you should consider increasing maxEventQueueSize in the config to allow more log events to be buffer before having to drop them.
+     */
+    public long getDiscardedCount() {
+        return discardedCount;
+    }
+}

--- a/src/main/java/com/boxfuse/cloudwatchlogs/internal/CloudwatchLogsLogEventFactory.java
+++ b/src/main/java/com/boxfuse/cloudwatchlogs/internal/CloudwatchLogsLogEventFactory.java
@@ -1,0 +1,22 @@
+package com.boxfuse.cloudwatchlogs.internal;
+
+/**
+ * Created by kawnayeen on 3/2/17.
+ */
+public class CloudwatchLogsLogEventFactory {
+    public static CloudwatchLogsLogEvent getLogEvent(LogEventWrapper logEventWrapper) {
+        return new CloudwatchLogsLogEvent(
+                logEventWrapper.getLevel(),
+                logEventWrapper.getLoggerName(),
+                logEventWrapper.getEventId(),
+                logEventWrapper.getMessage(),
+                logEventWrapper.getTimeInMillis(),
+                logEventWrapper.getThreadName(),
+                logEventWrapper.getAccount(),
+                logEventWrapper.getAction(),
+                logEventWrapper.getUser(),
+                logEventWrapper.getSession(),
+                logEventWrapper.getRequest()
+        );
+    }
+}

--- a/src/main/java/com/boxfuse/cloudwatchlogs/internal/CloudwatchLogsLogEventPutter.java
+++ b/src/main/java/com/boxfuse/cloudwatchlogs/internal/CloudwatchLogsLogEventPutter.java
@@ -6,24 +6,14 @@ import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.logs.AWSLogs;
 import com.amazonaws.services.logs.AWSLogsClient;
-import com.amazonaws.services.logs.model.InputLogEvent;
-import com.amazonaws.services.logs.model.InvalidSequenceTokenException;
-import com.amazonaws.services.logs.model.OperationAbortedException;
-import com.amazonaws.services.logs.model.PutLogEventsRequest;
-import com.amazonaws.services.logs.model.PutLogEventsResult;
-import com.amazonaws.services.logs.model.ServiceUnavailableException;
+import com.amazonaws.services.logs.model.*;
 import com.boxfuse.cloudwatchlogs.CloudwatchLogsConfig;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.concurrent.BlockingQueue;
 
 public class CloudwatchLogsLogEventPutter implements Runnable {

--- a/src/main/java/com/boxfuse/cloudwatchlogs/internal/LogEventWrapper.java
+++ b/src/main/java/com/boxfuse/cloudwatchlogs/internal/LogEventWrapper.java
@@ -1,0 +1,13 @@
+package com.boxfuse.cloudwatchlogs.internal;
+
+/**
+ * Created by kawnayeen on 3/2/17.
+ */
+public interface LogEventWrapper {
+    String getAccount();
+    String getAction();
+    String getUser();
+    String getSession();
+    String getRequest();
+    String getEventId();
+}

--- a/src/main/java/com/boxfuse/cloudwatchlogs/internal/LogEventWrapper.java
+++ b/src/main/java/com/boxfuse/cloudwatchlogs/internal/LogEventWrapper.java
@@ -5,9 +5,24 @@ package com.boxfuse.cloudwatchlogs.internal;
  */
 public interface LogEventWrapper {
     String getAccount();
+
     String getAction();
+
     String getUser();
+
     String getSession();
+
     String getRequest();
+
     String getEventId();
+
+    String getMessage();
+
+    String getLevel();
+
+    String getLoggerName();
+
+    long getTimeInMillis();
+
+    String getThreadName();
 }

--- a/src/main/java/com/boxfuse/cloudwatchlogs/log4j2/Log4j2LogEventWrapper.java
+++ b/src/main/java/com/boxfuse/cloudwatchlogs/log4j2/Log4j2LogEventWrapper.java
@@ -45,4 +45,50 @@ public class Log4j2LogEventWrapper implements LogEventWrapper {
         Marker marker = event.getMarker();
         return marker == null ? null : marker.getName();
     }
+
+    @Override
+    public String getMessage() {
+        String message = event.getMessage().getFormattedMessage();
+        Throwable throwable = event.getThrown();
+        while (throwable != null) {
+            message += "\n" + dump(throwable);
+            throwable = throwable.getCause();
+            if (throwable != null) {
+                message += "\nCaused by:";
+            }
+        }
+        return message;
+    }
+
+    @Override
+    public String getLevel() {
+        return event.getLevel().toString();
+    }
+
+    @Override
+    public String getLoggerName() {
+        return event.getLoggerName();
+    }
+
+    @Override
+    public long getTimeInMillis() {
+        return event.getTimeMillis();
+    }
+
+    @Override
+    public String getThreadName() {
+        return event.getThreadName();
+    }
+
+    private String dump(Throwable throwableProxy) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(throwableProxy.getMessage()).append("\n");
+        for (StackTraceElement step : throwableProxy.getStackTrace()) {
+            String string = step.toString();
+            builder.append("\t").append(string);
+            builder.append(step);
+            builder.append("\n");
+        }
+        return builder.toString();
+    }
 }

--- a/src/main/java/com/boxfuse/cloudwatchlogs/log4j2/Log4j2LogEventWrapper.java
+++ b/src/main/java/com/boxfuse/cloudwatchlogs/log4j2/Log4j2LogEventWrapper.java
@@ -1,0 +1,48 @@
+package com.boxfuse.cloudwatchlogs.log4j2;
+
+import com.boxfuse.cloudwatchlogs.CloudwatchLogsMDCPropertyNames;
+import com.boxfuse.cloudwatchlogs.internal.LogEventWrapper;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.core.LogEvent;
+
+/**
+ * Created by kawnayeen on 3/2/17.
+ */
+public class Log4j2LogEventWrapper implements LogEventWrapper {
+    private LogEvent event;
+
+    public Log4j2LogEventWrapper(LogEvent event) {
+        this.event = event;
+    }
+
+    @Override
+    public String getAccount() {
+        return event.getContextData().getValue(CloudwatchLogsMDCPropertyNames.ACCOUNT);
+    }
+
+    @Override
+    public String getAction() {
+        return event.getContextData().getValue(CloudwatchLogsMDCPropertyNames.ACTION);
+    }
+
+    @Override
+    public String getUser() {
+        return event.getContextData().getValue(CloudwatchLogsMDCPropertyNames.USER);
+    }
+
+    @Override
+    public String getSession() {
+        return event.getContextData().getValue(CloudwatchLogsMDCPropertyNames.SESSION);
+    }
+
+    @Override
+    public String getRequest() {
+        return event.getContextData().getValue(CloudwatchLogsMDCPropertyNames.REQUEST);
+    }
+
+    @Override
+    public String getEventId() {
+        Marker marker = event.getMarker();
+        return marker == null ? null : marker.getName();
+    }
+}

--- a/src/main/java/com/boxfuse/cloudwatchlogs/logback/CloudwatchLogsLogbackAppender.java
+++ b/src/main/java/com/boxfuse/cloudwatchlogs/logback/CloudwatchLogsLogbackAppender.java
@@ -1,16 +1,12 @@
 package com.boxfuse.cloudwatchlogs.logback;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.classic.spi.IThrowableProxy;
-import ch.qos.logback.classic.spi.StackTraceElementProxy;
-import ch.qos.logback.classic.spi.ThrowableProxyUtil;
 import ch.qos.logback.core.AppenderBase;
-import ch.qos.logback.core.CoreConstants;
 import com.boxfuse.cloudwatchlogs.CloudwatchLogsConfig;
-import com.boxfuse.cloudwatchlogs.CloudwatchLogsMDCPropertyNames;
 import com.boxfuse.cloudwatchlogs.internal.CloudwatchAppender;
 import com.boxfuse.cloudwatchlogs.internal.CloudwatchLogsLogEvent;
-import org.slf4j.Marker;
+import com.boxfuse.cloudwatchlogs.internal.CloudwatchLogsLogEventFactory;
+import com.boxfuse.cloudwatchlogs.internal.LogEventWrapper;
 
 /**
  * LogBack appender for Boxfuse's AWS CloudWatch Logs integration.
@@ -48,37 +44,8 @@ public class CloudwatchLogsLogbackAppender extends AppenderBase<ILoggingEvent> {
 
     @Override
     protected void append(ILoggingEvent event) {
-        String message = event.getFormattedMessage();
-        IThrowableProxy throwableProxy = event.getThrowableProxy();
-        while (throwableProxy != null) {
-            message += "\n" + dump(throwableProxy);
-            throwableProxy = throwableProxy.getCause();
-            if (throwableProxy != null) {
-                message += "\nCaused by:";
-            }
-        }
-
-        String account = event.getMDCPropertyMap().get(CloudwatchLogsMDCPropertyNames.ACCOUNT);
-        String action = event.getMDCPropertyMap().get(CloudwatchLogsMDCPropertyNames.ACTION);
-        String user = event.getMDCPropertyMap().get(CloudwatchLogsMDCPropertyNames.USER);
-        String session = event.getMDCPropertyMap().get(CloudwatchLogsMDCPropertyNames.SESSION);
-        String request = event.getMDCPropertyMap().get(CloudwatchLogsMDCPropertyNames.REQUEST);
-
-        Marker marker = event.getMarker();
-        String eventId = marker == null ? null : marker.getName();
-        CloudwatchLogsLogEvent logEvent = new CloudwatchLogsLogEvent(event.getLevel().toString(), event.getLoggerName(), eventId, message, event.getTimeStamp(), event.getThreadName(), account, action, user, session, request);
+        LogEventWrapper logEventWrapper = new LogbackLogEventWrapper(event);
+        CloudwatchLogsLogEvent logEvent = CloudwatchLogsLogEventFactory.getLogEvent(logEventWrapper);
         cloudwatchAppender.append(logEvent);
-    }
-
-    private String dump(IThrowableProxy throwableProxy) {
-        StringBuilder builder = new StringBuilder();
-        builder.append(throwableProxy.getMessage()).append(CoreConstants.LINE_SEPARATOR);
-        for (StackTraceElementProxy step : throwableProxy.getStackTraceElementProxyArray()) {
-            String string = step.toString();
-            builder.append(CoreConstants.TAB).append(string);
-            ThrowableProxyUtil.subjoinPackagingData(builder, step);
-            builder.append(CoreConstants.LINE_SEPARATOR);
-        }
-        return builder.toString();
     }
 }

--- a/src/main/java/com/boxfuse/cloudwatchlogs/logback/LogbackLogEventWrapper.java
+++ b/src/main/java/com/boxfuse/cloudwatchlogs/logback/LogbackLogEventWrapper.java
@@ -1,6 +1,10 @@
 package com.boxfuse.cloudwatchlogs.logback;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.StackTraceElementProxy;
+import ch.qos.logback.classic.spi.ThrowableProxyUtil;
+import ch.qos.logback.core.CoreConstants;
 import com.boxfuse.cloudwatchlogs.CloudwatchLogsMDCPropertyNames;
 import com.boxfuse.cloudwatchlogs.internal.LogEventWrapper;
 import org.slf4j.Marker;
@@ -44,5 +48,52 @@ public class LogbackLogEventWrapper implements LogEventWrapper {
     public String getEventId() {
         Marker marker = event.getMarker();
         return marker == null ? null : marker.getName();
+    }
+
+    @Override
+    public String getMessage() {
+        String message = event.getFormattedMessage();
+        IThrowableProxy throwableProxy = event.getThrowableProxy();
+        while (throwableProxy != null) {
+            message += "\n" + dump(throwableProxy);
+            throwableProxy = throwableProxy.getCause();
+            if (throwableProxy != null) {
+                message += "\nCaused by:";
+            }
+        }
+        return message;
+    }
+
+    @Override
+    public String getLevel() {
+        return event.getLevel().toString();
+    }
+
+    @Override
+    public String getLoggerName() {
+        return event.getLoggerName();
+    }
+
+    @Override
+    public long getTimeInMillis() {
+        return event.getTimeStamp();
+    }
+
+    @Override
+    public String getThreadName() {
+        return event.getThreadName();
+    }
+
+    private String dump(IThrowableProxy throwableProxy) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(throwableProxy.getMessage()).append(CoreConstants.LINE_SEPARATOR);
+        for (StackTraceElementProxy step : throwableProxy.getStackTraceElementProxyArray()) {
+            String string = step.toString();
+            builder.append(CoreConstants.TAB).append(string);
+            ThrowableProxyUtil.subjoinPackagingData(builder, step);
+            builder.append(CoreConstants.LINE_SEPARATOR);
+        }
+        return builder.toString();
+
     }
 }

--- a/src/main/java/com/boxfuse/cloudwatchlogs/logback/LogbackLogEventWrapper.java
+++ b/src/main/java/com/boxfuse/cloudwatchlogs/logback/LogbackLogEventWrapper.java
@@ -1,0 +1,48 @@
+package com.boxfuse.cloudwatchlogs.logback;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import com.boxfuse.cloudwatchlogs.CloudwatchLogsMDCPropertyNames;
+import com.boxfuse.cloudwatchlogs.internal.LogEventWrapper;
+import org.slf4j.Marker;
+
+/**
+ * Created by kawnayeen on 3/2/17.
+ */
+public class LogbackLogEventWrapper implements LogEventWrapper {
+    private ILoggingEvent event;
+
+    public LogbackLogEventWrapper(ILoggingEvent loggingEvent) {
+        this.event = loggingEvent;
+    }
+
+    @Override
+    public String getAccount() {
+        return event.getMDCPropertyMap().get(CloudwatchLogsMDCPropertyNames.ACCOUNT);
+    }
+
+    @Override
+    public String getAction() {
+        return event.getMDCPropertyMap().get(CloudwatchLogsMDCPropertyNames.ACTION);
+    }
+
+    @Override
+    public String getUser() {
+        return event.getMDCPropertyMap().get(CloudwatchLogsMDCPropertyNames.USER);
+    }
+
+    @Override
+    public String getSession() {
+        return event.getMDCPropertyMap().get(CloudwatchLogsMDCPropertyNames.SESSION);
+    }
+
+    @Override
+    public String getRequest() {
+        return event.getMDCPropertyMap().get(CloudwatchLogsMDCPropertyNames.REQUEST);
+    }
+
+    @Override
+    public String getEventId() {
+        Marker marker = event.getMarker();
+        return marker == null ? null : marker.getName();
+    }
+}


### PR DESCRIPTION
Hi, I've removed duplication of code where ever possible, centralised the appender implementation at CloudwatchAppender. So, CloudwatchLogsLog4j2Appender & CloudwatchLogsLogbackAppender is using CloudwatchAppender, which makes the code much easier to maintain. As in future we need to modify appender logic at one place. I've also created LogEventWrapper which wrap different LoggingEvent to a common interface. That really make it easy to integrate any new Logging api, as we just need to implement the LogEventWrapper interface.